### PR TITLE
Update fn_error.sqf

### DIFF
--- a/Revolution.malden/Functions/UtilityScripts/fn_error.sqf
+++ b/Revolution.malden/Functions/UtilityScripts/fn_error.sqf
@@ -11,18 +11,17 @@
  Nothing
 */
 
-params["_msg"];
-
-_msg = _this select 0;
+params["_msg","",[""]];
+if (_msg IsEqualTo "") exitWith {};
 
 [_msg] call BIS_fnc_error;
 
 createDialog "errorDialog";
 
-i = 0; 
-while {i < 10} do  
+private _i = 0; 
+while {_i < 10} do  
 { 
-	i = i +1; 
+	_i = _i +1; 
 	playSound "addItemFailed";
 };  
 


### PR DESCRIPTION
params can do the same job as _msg = _this select 0 and it's better to have and isn't better to have "i" has a local private var?

not sure if all the syntax is correct it shuold be